### PR TITLE
Add row-based, concrete, batch operator

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -46,6 +46,25 @@ func BenchmarkRowBasedTyped(b *testing.B) {
 	}
 }
 
+func BenchmarkRowBasedTypedBatch(b *testing.B) {
+	scan := &typedBatchTableReader{rows: makeTypedBatchInput(numRows, numCols, Int64Type)}
+	render := mulInt64BatchOperator{
+		input:             scan,
+		arg:               2,
+		columnsToMultiply: []int{0},
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for {
+			row := render.next()
+			if row == nil {
+				break
+			}
+		}
+		scan.reset()
+	}
+}
+
 func BenchmarkColBasedTyped(b *testing.B) {
 	scan := makeTypedColInput(numRows, numCols, Int64Type)
 	render := mulInt64ColOperator{

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -3,7 +3,7 @@ package main
 import "testing"
 
 const (
-	numRows = 4096
+	numRows = 50000
 	numCols = 1
 )
 

--- a/col_based_typed.go
+++ b/col_based_typed.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 )
 
-const batchSize = 1024
-
 type vector interface {
 	// Type returns the type of data stored in this vector.
 	Type() T

--- a/row_based_typed_batch.go
+++ b/row_based_typed_batch.go
@@ -1,0 +1,93 @@
+package main
+
+const batchSize = 1024
+
+type TypedBatchOperator interface {
+	next() [][]TypedDatum
+}
+
+type mulInt64BatchOperator struct {
+	input             TypedBatchOperator
+	arg               int64
+	columnsToMultiply []int
+}
+
+func (m mulInt64BatchOperator) next() [][]TypedDatum {
+	rows := m.input.next()
+	if rows == nil {
+		return nil
+	}
+	for _, row := range rows {
+		for _, c := range m.columnsToMultiply {
+			row[c] = TypedDatum{t: Int64Type, int64: row[c].int64 * m.arg}
+		}
+	}
+	return rows
+}
+
+type mulFloat64BatchOperator struct {
+	input             TypedBatchOperator
+	arg               float64
+	columnsToMultiply []int
+}
+
+func (m mulFloat64BatchOperator) next() [][]TypedDatum {
+	rows := m.input.next()
+	if rows == nil {
+		return nil
+	}
+	for _, row := range rows {
+		for _, c := range m.columnsToMultiply {
+			row[c] = TypedDatum{t: Float64Type, float64: row[c].float64 * m.arg}
+		}
+	}
+	return rows
+}
+
+type typedBatchTableReader struct {
+	curIdx int
+	rows   [][]TypedDatum
+}
+
+func (t *typedBatchTableReader) next() [][]TypedDatum {
+	if t.curIdx >= len(t.rows) {
+		return nil
+	}
+	endIdx := t.curIdx + batchSize
+	if endIdx > len(t.rows) {
+		endIdx = len(t.rows)
+	}
+	retRows := t.rows[t.curIdx:endIdx]
+	t.curIdx = endIdx
+	return retRows
+}
+
+func (t *typedBatchTableReader) reset() {
+	t.curIdx = 0
+}
+
+// makeTypedInput creates numRows rows of numCols each of the given type. For
+// each  row, all of its columns will be its index (zero-indexed).
+func makeTypedBatchInput(numRows int, numCols int, t T) [][]TypedDatum {
+	result := make([][]TypedDatum, numRows)
+	for i := range result {
+		result[i] = make([]TypedDatum, numCols)
+	}
+	switch t {
+	case Int64Type:
+		for i := 0; i < numRows; i++ {
+			for j := 0; j < numCols; j++ {
+				result[i][j] = TypedDatum{t: t, int64: int64(i)}
+			}
+		}
+	case Float64Type:
+		for i := 0; i < numRows; i++ {
+			for j := 0; j < numCols; j++ {
+				result[i][j] = TypedDatum{t: t, float64: float64(i)}
+			}
+		}
+	default:
+		panic("unhandled type")
+	}
+	return result
+}


### PR DESCRIPTION
This is a transition between the row-based concrete version and the
col-based batch version.

Also, increase the row count in the benchmark.

    BenchmarkRowBasedInterface-12               2000            577920 ns/op
    BenchmarkRowBasedTyped-12                   5000            299461 ns/op
    BenchmarkRowBasedTypedBatch-12             20000             84884 ns/op
    BenchmarkColBasedTyped-12                  50000             27611 ns/op
    BenchmarkSpeedOfLight-12                  100000             12036 ns/op